### PR TITLE
[FE] 게시글 상세 보기 페이지 (boardshow.html) 구현

### DIFF
--- a/src/main/java/com/example/capstone2/SecurityConfig.java
+++ b/src/main/java/com/example/capstone2/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                                         "/login",
                                         "/register",
                                         "/createboard",
+                                        "/board/show/**",
                                         "/boardpage",
                                         "/board/modify/**",
                                         "/mypage",

--- a/src/main/java/com/example/capstone2/controller/ViewController.java
+++ b/src/main/java/com/example/capstone2/controller/ViewController.java
@@ -43,4 +43,8 @@ public class ViewController {
         return "modifyboardpage"; // templates/modifyboardpage.html
     }
 
+    @GetMapping("/board/show/{id}")
+    public String showBoardPage(@PathVariable Long id) {
+        return "boardshow"; // boardshow.html
+    }
 }

--- a/src/main/resources/templates/boardpage.html
+++ b/src/main/resources/templates/boardpage.html
@@ -170,27 +170,26 @@
             const div = document.createElement('div');
             div.className = 'list-group-item';
             div.innerHTML = `
-                <div class="d-flex justify-content-between align-items-center">
-                    <div onclick="location.href='/board/${board.id}'" style="cursor:pointer;">
-                        <span class="badge bg-secondary mb-2">${convertCategoryToKorean(board.category)}</span>
-                        <h5 class="mb-1">${board.title}</h5>
-                        <p class="mb-1">${board.description}</p>
-                    </div>
-                    <div class="d-flex align-items-center">
-                        <label class="switch me-2">
-                            <input type="checkbox" ${board.closed === false ? 'checked' : ''} onchange="toggleStatus(${board.id}, this)">
-                            <span class="slider"></span>
-                        </label>
-                        <button class="btn btn-sm btn-success me-2" onclick="apply(${board.id})">참여 신청</button>
-                        <button class="btn btn-sm btn-warning me-2" onclick="moveToModify(${board.id})">수정</button>
-                        <button class="btn btn-sm btn-danger" onclick="deleteBoard(${board.id})">삭제</button>
-                    </div>
+            <div class="d-flex justify-content-between align-items-center">
+                <div class="clickable-area" data-id="${board.id}" style="flex: 1; cursor: pointer;">
+                    <span class="badge bg-secondary mb-2">${convertCategoryToKorean(board.category)}</span>
+                    <h5 class="mb-1">${board.title}</h5>
+                    <p class="mb-1">${board.description}</p>
                 </div>
-            `;
+                <div class="d-flex align-items-center ms-3">
+                    <label class="switch me-2">
+                        <input type="checkbox" ${board.closed === false ? 'checked' : ''} onchange="toggleStatus(${board.id}, this)">
+                        <span class="slider"></span>
+                    </label>
+                    <button class="btn btn-sm btn-success me-2" onclick="apply(${board.id})">참여 신청</button>
+                    <button class="btn btn-sm btn-warning me-2" onclick="moveToModify(${board.id})">수정</button>
+                    <button class="btn btn-sm btn-danger" onclick="deleteBoard(${board.id})">삭제</button>
+                </div>
+            </div>
+        `;
             container.appendChild(div);
         });
     }
-
     function renderPagination() {
         const paginationContainer = document.getElementById('pagination');
         paginationContainer.innerHTML = '';
@@ -318,6 +317,13 @@
     document.addEventListener('DOMContentLoaded', () => {
         loadCategoryOptions();
         fetchBoards();
+        document.addEventListener('click', function(e) {
+            const target = e.target.closest('.clickable-area');
+            if (target) {
+                const id = target.getAttribute('data-id');
+                location.href = `/board/show/${id}`;
+            }
+        });
     });
 
     function moveToModify(boardId) {

--- a/src/main/resources/templates/boardshow.html
+++ b/src/main/resources/templates/boardshow.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>게시글 보기 | Time Bank</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #A7D7A3;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-family: 'Segoe UI', sans-serif;
+        }
+        .view-container {
+            background: #fff;
+            border-radius: 20px;
+            padding: 2rem;
+            width: 100%;
+            max-width: 800px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+        }
+        .participant-box {
+            border: 1px solid #D0E8D0;
+            border-radius: 10px;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #F6FFF6;
+        }
+        .label-title {
+            font-weight: bold;
+            color: #3E7C4A;
+        }
+        .content-block {
+            margin-bottom: 1.5rem;
+        }
+    </style>
+</head>
+<body>
+<div class="view-container">
+    <h2 class="mb-4 text-center" style="color:#3E7C4A;">게시글 상세</h2>
+
+    <!-- 게시글 정보 (읽기 전용) -->
+    <div class="content-block">
+        <div class="label-title">제목</div>
+        <p id="title" class="form-control-plaintext"></p>
+    </div>
+    <div class="content-block">
+        <div class="label-title">내용</div>
+        <p id="description" class="form-control-plaintext"></p>
+    </div>
+    <div class="content-block">
+        <div class="label-title">카테고리</div>
+        <p id="category" class="form-control-plaintext"></p>
+    </div>
+    <div class="content-block">
+        <div class="label-title">크레딧 가격</div>
+        <p id="creditPrice" class="form-control-plaintext"></p>
+    </div>
+    <div class="d-grid gap-2 mb-4">
+        <button type="button" class="btn btn-secondary" onclick="location.href='/boardpage'">뒤로 가기</button>
+    </div>
+
+    <!-- 참여자 목록 -->
+    <h4 class="mt-4 mb-3" style="color:#3E7C4A;">참여 요청자 목록</h4>
+    <div id="participants-list"></div>
+
+    <!-- 승인된 참여자 목록 -->
+    <h4 class="mt-4 mb-3" style="color:#3E7C4A;">승인된 참여자 목록</h4>
+    <div id="approved-participants-list"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+<script>
+    const token = localStorage.getItem('accessToken');
+    const boardId = location.pathname.split('/').pop();
+
+    async function loadBoard() {
+        try {
+            const res = await axios.get(`/api/boards/${boardId}`, { headers: { Authorization: token } });
+            const board = res.data;
+            document.getElementById('title').innerText = board.title;
+            document.getElementById('description').innerText = board.description;
+            document.getElementById('category').innerText = convertCategory(board.category);
+            document.getElementById('creditPrice').innerText = board.creditPrice + " 크레딧";
+        } catch (err) {
+            console.error(err);
+            alert('게시글 정보를 불러오지 못했습니다.');
+        }
+    }
+
+    async function loadParticipants() {
+        try {
+            const res = await axios.get(`/api/boards/${boardId}/allregister`, { headers: { Authorization: token } });
+            const container = document.getElementById('participants-list');
+            container.innerHTML = '';
+            res.data.forEach(p => {
+                if (p.status === 'PENDING') {
+                    const div = document.createElement('div');
+                    div.className = 'participant-box';
+                    div.innerHTML = `<p><strong>유저 ID:</strong> ${p.userId}</p>`;
+                    container.appendChild(div);
+                }
+            });
+        } catch (err) {
+            console.error(err);
+            alert('참여자 목록을 불러오지 못했습니다.');
+        }
+    }
+
+    async function loadApprovedParticipants() {
+        try {
+            const res = await axios.get(`/api/boards/${boardId}/approved-participants`, {
+                headers: { Authorization: token }
+            });
+            const container = document.getElementById('approved-participants-list');
+            container.innerHTML = '';
+            res.data.forEach(p => {
+                const div = document.createElement('div');
+                div.className = 'participant-box';
+                div.innerHTML = `<p><strong>유저 ID:</strong> ${p.userId}</p>`;
+                container.appendChild(div);
+            });
+        } catch (err) {
+            console.error(err);
+            alert('승인된 참여자 목록을 불러오지 못했습니다.');
+        }
+    }
+
+    function convertCategory(category) {
+        const map = {
+            EDUCATION: "교육 & 학습",
+            IT: "IT & 개발",
+            DESIGN: "디자인 & 예술",
+            TRANSLATION: "번역 & 작문",
+            LIFESTYLE: "생활 & 취미",
+            ENGINEERING: "공학 & 과학",
+            BUSINESS: "비즈니스 & 금융",
+            VOLUNTEERING: "사회봉사 & 공익",
+            HEALTHCARE: "건강 & 의료",
+            SPORTS: "스포츠 & 트레이닝",
+            COOKING: "요리 & 베이킹",
+            ETC: "기타 맞춤형 재능"
+        };
+        return map[category] || category;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        loadBoard();
+        loadParticipants();
+        loadApprovedParticipants();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## ✨ 작업 개요
- 게시글 클릭 시 상세 내용을 볼 수 있는 `boardshow.html` 페이지 추가
- 수정 및 승인/거절/환불 기능은 제거하고 **읽기 전용**으로 구성

---

## 📁 변경 사항
1. **게시글 상세 페이지 (`boardshow.html`) 추가**
   - 제목, 내용, 카테고리, 크레딧 가격 등 게시글 정보 표시
   - 참여 요청자, 승인된 참여자 목록 표시 (읽기 전용)
2. `boardpage.html`에서 게시글 클릭 시 `/board/show/{id}`로 이동하도록 수정
3. 버튼이나 입력 필드 없이 전체가 읽기 전용 형태로 구현

---

## 🔒 제한 사항
- `수정`, `참여 승인`, `참여 거절`, `환불` 기능은 이 페이지에서 **불가**
- 위 기능은 `수정 페이지 (boardmodify.html)`에서만 가능

---

## 🧪 테스트 방법
- 게시글 목록에서 임의의 게시글 클릭  
→ `/board/show/{id}`로 이동  
→ 상세 내용과 참여자 목록 정상 표시 확인  
→ 수정 및 승인 관련 버튼이 없는지 확인

---

## 📎 기타
- 추후 버튼 스타일 통일 및 라우팅 통합 필요 시 논의
- 관리자 기능 분리 여부도 고려 가능